### PR TITLE
[simplur] Add typedefs

### DIFF
--- a/simplur/index.d.ts
+++ b/simplur/index.d.ts
@@ -1,0 +1,2 @@
+const templatingFunction: (strings: TemplateStringsArray, ...amounts: number[]) => string;
+export default templatingFunction;


### PR DESCRIPTION
This adds a typescript definition which allows typescript users to use and typecheck simplur.

```ts
simplur`${'1'} error[|s]` // 🚨 TS2345: Argument of type '"1"' is not assignable to parameter of type 'number'.
simplur`${1} error[|s]` // ✅
```