### PR TITLE
Add typescript types definition to simplur

### DIFF
--- a/simplur/index.d.ts
+++ b/simplur/index.d.ts
@@ -1,0 +1,2 @@
+declare function _exports(strings: any, ...exps: any[]): string;
+export = _exports;

--- a/simplur/package.json
+++ b/simplur/package.json
@@ -3,9 +3,11 @@
   "version": "1.1.0",
   "description": "Simple, versatile string pluralization",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "prepare": "npm test && runmd --output=README.md src/README_js.md",
-    "test": "mocha src/test.js"
+    "test": "mocha src/test.js",
+    "generate:types": "npx typescript index.js --declaration --allowJs --emitDeclarationOnly --outDir ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there!
I've been enjoying this nifty little library, so thanks for making it! 😄

I'm running typescript with `noImplicitAny: true` mode on my project, so I quickly noticed that there weren't any types definitions for the library. 
I'm not sure what package https://github.com/broofa/BroofaJS/issues/6 was referring to so I'm not sure this would solve the problem entirely, but other people are probably running into the same issue so I figured I'd make a PR to help with that at the source!

I also added a command for automatically generating types from your .js code: `npm run generate:types`, so you can easily update the types if you make changes to the library in the future.

Disclaimer: the types could be made more specific, but I wanted to keep the "barrier to entry" for this as low as possible and make it as easy as possible to define the types (in this case, generating them automatically from .js files doesn't require any knowledge of typescript, per se).

Let me know if there's anything that you want to be changed or are not super sure about!