### PR TITLE
simplur: omit quantity

### DIFF
--- a/simplur/index.js
+++ b/simplur/index.js
@@ -8,7 +8,7 @@ module.exports = function(strings, ...exps) {
   let n = exps[0];
   let label = n;
   if (Array.isArray(n) && n.length == 2 && typeof(n[1]) == 'function') {
-    label = n[1](n[0]) || n[0];
+    label = n[1](n[0]);
     n = n[0];
   }
 
@@ -22,11 +22,11 @@ module.exports = function(strings, ...exps) {
     if (!exps.length) break;
     n = label = exps.shift();
     if (Array.isArray(n) && n.length == 2 && typeof(n[1]) == 'function') {
-      label = n[1](n[0]) || n[0];
+      label = n[1](n[0]);
       n = n[0];
     }
     result.push(label);
   }
 
-  return result.join('');
+  return result.join('').trim();
 }

--- a/simplur/index.js
+++ b/simplur/index.js
@@ -7,8 +7,8 @@ module.exports = function(strings, ...exps) {
   const result = [];
   let n = exps[0];
   let label = n;
-  if (Array.isArray(n) && n.length == 2 && typeof(n[1]) == 'function') {
-    label = n[1](n[0]);
+  if (Array.isArray(n)) {
+    label = typeof n[1] == 'function' ? n[1](n[0]) : null;
     n = n[0];
   }
 
@@ -21,12 +21,12 @@ module.exports = function(strings, ...exps) {
 
     if (!exps.length) break;
     n = label = exps.shift();
-    if (Array.isArray(n) && n.length == 2 && typeof(n[1]) == 'function') {
-      label = n[1](n[0]);
+    if (Array.isArray(n)) {
+      label = typeof n[1] == 'function' ? n[1](n[0]) : null;
       n = n[0];
     }
     result.push(label);
   }
 
-  return result.join('').trim();
-}
+  return result.join('');
+};

--- a/simplur/src/test.js
+++ b/simplur/src/test.js
@@ -22,13 +22,17 @@ describe('simplur', () => {
     assert.equal(simplur`There [is|are] ${2} m[an|en]`, 'There are 2 men');
   });
 
+  it('Omit quantity', () => {
+    assert.equal(simplur`${[1, () => null]} [This|These] [man|men]`, 'This man');
+  });
+
   it('Custom units', () => {
     function units(val) {
       return val < 1 ? 'no' :
         val == 1 ? 'only' :
         val == 2 ? 'both' :
         val < 5 ? 'a few' :
-        null;
+        val;
     }
 debugger;
     assert.equal(simplur`${[0, units]} t[ooth|eeth]`, 'no teeth');

--- a/simplur/src/test.js
+++ b/simplur/src/test.js
@@ -23,7 +23,8 @@ describe('simplur', () => {
   });
 
   it('Omit quantity', () => {
-    assert.equal(simplur`${[1, () => null]} [This|These] [man|men]`, 'This man');
+    assert.equal(simplur`${[1]}[This|These] [man|men]`, 'This man');
+    assert.equal(simplur`${[2]}[This|These] [man|men]`, 'These men');
   });
 
   it('Custom units', () => {


### PR DESCRIPTION
This PR allows to omit the quantity on the output string.
The output of the `formatQuantity` function goes into the output string, so if an empty string or null or undefined are return, the quantity will be omitted in the output string. `trim()` was used to remove leading/trailing spaces after joining the results.

This is a breaking change tho, as with current code when `formatQuantity` function returns null, the quantity is not omitted.

Let me know what you think.